### PR TITLE
Fix a bug with npz and add replace --no-sum--layer with new --layer option

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.3.0 - 2020-05-14
+
+ * Changed `--no-sum-layers` to `--layer` with options `sum`, `all`, `CNN`, `LSTM1` and `LSTM2`. The default remains summing up all three layer.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "seqvec"
-version = "0.2.1"
+version = "0.3.0"
 description = "Embeeder tool for 'Modelling the Language of Life - Deep Learning Protein Sequences'"
 authors = ["Michael Heinzinger <mheinzinger@rostlab.org>"]
 repository = "https://github.com/Rostlab/SeqVec"

--- a/seqvec/seqvec.py
+++ b/seqvec/seqvec.py
@@ -221,7 +221,7 @@ def save_from_generator(
                     # noinspection PyUnboundLocalVariable
                     hf.create_dataset(sequence_id, data=embedding)
     elif emb_path.suffix == ".npz" or emb_path.suffix == ".npy":
-        if not per_protein:
+        if emb_path.suffix == ".npy" and not per_protein:
             raise RuntimeError(
                 "You need to sum up per protein (`--protein True`) to save as .npy array"
             )
@@ -285,7 +285,7 @@ def create_arg_parser():
         "--output",
         required=True,
         type=Path,
-        help="A path to a file for saving the created embeddings. " 
+        help="A path to a file for saving the created embeddings. "
         + "By default, a HDF (.h5) file will be written which should also be indicated by the chosen filename."
         + "Only if you create per-protein embeddings, you can also write to numpy formats, i.e. .npy or .npz, which again should be indicated by the chosen filename."
         + "If you choose to write a .npy file, a .json file with the sequence ids will be created next to the .npy file.",


### PR DESCRIPTION
The first commit fixes a false error with npz and when per_protein is not set, the second replaces `--no-sum-layers` with a more general `--layer` with 5 options: `sum`, `all`, `CNN`, `LSTM1` and `LSTM2`.